### PR TITLE
Fix destination sorting

### DIFF
--- a/react-ui/src/components/DestinationOptions/destination-options.js
+++ b/react-ui/src/components/DestinationOptions/destination-options.js
@@ -28,7 +28,7 @@ const OPTIONS = [
     ["Sunday River - Snow Cap Inn", "mharrop@sundayriver.com"],
 ];
 
-const sortedOptions = [...OPTIONS].sort((a, b) => a[0] > b[0]);
+const sortedOptions = [...OPTIONS].sort((a, b) => a[0].localeCompare(b[0]));
 sortedOptions.unshift(['Other', '']);
 
 const DestinationOptions = ({ handleSelect }) => {


### PR DESCRIPTION
Fix the ordering of the destination dropdown.

Comparing strings via `>` returns a boolean, whereas the `sort` method expects `-1`, `0`, or `-`. This was causing incorrect ordering in [certain browsers](https://bugs.chromium.org/p/v8/issues/detail?id=103).